### PR TITLE
fix(scheduler): prevent double-firing when agent run exceeds 60s

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -292,6 +292,19 @@ export function getAllScheduledTasks(): ScheduledTask[] {
     .all() as ScheduledTask[];
 }
 
+/**
+ * Advance next_run immediately when a task is picked up so the scheduler
+ * cannot re-fire the same task while the agent is still running.
+ * Call this before starting the agent; updateTaskAfterRun will overwrite
+ * next_run again once the agent finishes.
+ */
+export function markTaskRunning(id: string, nextRun: number): void {
+  db.prepare(`UPDATE scheduled_tasks SET next_run = ? WHERE id = ?`).run(
+    nextRun,
+    id,
+  );
+}
+
 export function updateTaskAfterRun(
   id: string,
   nextRun: number,

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -3,6 +3,7 @@ import { CronExpressionParser } from 'cron-parser';
 import { ALLOWED_CHAT_ID } from './config.js';
 import {
   getDueTasks,
+  markTaskRunning,
   updateTaskAfterRun,
 } from './db.js';
 import { logger } from './logger.js';
@@ -12,6 +13,11 @@ import { formatForTelegram } from './bot.js';
 type Sender = (text: string) => Promise<void>;
 
 let sender: Sender;
+
+// In-memory guard: task IDs currently being executed.
+// Prevents re-firing a long-running task on the next 60s tick before
+// updateTaskAfterRun has had a chance to advance next_run in the DB.
+const runningTaskIds = new Set<string>();
 
 /**
  * Initialise the scheduler. Call once after the Telegram bot is ready.
@@ -27,13 +33,19 @@ export function initScheduler(send: Sender): void {
 }
 
 async function runDueTasks(): Promise<void> {
-  const tasks = getDueTasks();
+  const tasks = getDueTasks().filter((t) => !runningTaskIds.has(t.id));
   if (tasks.length === 0) return;
 
   logger.info({ count: tasks.length }, 'Running due scheduled tasks');
 
   for (const task of tasks) {
     logger.info({ taskId: task.id, prompt: task.prompt.slice(0, 60) }, 'Firing task');
+
+    runningTaskIds.add(task.id);
+    // Advance next_run in the DB immediately so the task won't be picked up
+    // again by the next tick if the agent takes longer than 60 seconds.
+    const nextRun = computeNextRun(task.schedule);
+    markTaskRunning(task.id, nextRun);
 
     try {
       await sender(`Scheduled task running: "${task.prompt.slice(0, 80)}${task.prompt.length > 80 ? '...' : ''}"`);
@@ -44,8 +56,7 @@ async function runDueTasks(): Promise<void> {
 
       await sender(formatForTelegram(text));
 
-      const nextRun = computeNextRun(task.schedule);
-      updateTaskAfterRun(task.id, nextRun, text);
+      updateTaskAfterRun(task.id, computeNextRun(task.schedule), text);
 
       logger.info({ taskId: task.id, nextRun }, 'Task complete, next run scheduled');
     } catch (err) {
@@ -55,6 +66,8 @@ async function runDueTasks(): Promise<void> {
       } catch {
         // ignore send failure
       }
+    } finally {
+      runningTaskIds.delete(task.id);
     }
   }
 }


### PR DESCRIPTION
The scheduler polls every 60s and fires all tasks where next_run <= now. If an agent takes more than 60s, the same task would be picked up again on the next tick because updateTaskAfterRun (which advances next_run) had not been called yet.

Fix with two layers:
- markTaskRunning() bumps next_run in the DB before the agent starts, so a process restart cannot re-fire the task mid-run.
- runningTaskIds Set filters out in-flight tasks from getDueTasks() results, covering the same-process re-entry case with no DB round-trip.

<img width="1080" height="380" alt="CleanShot 2026-03-04 at 16 06 40@2x" src="https://github.com/user-attachments/assets/18f9cb8a-a824-4ca7-923e-4af9ca422927" />
