### PR TITLE
fix(memory): skip ingestion when Gemini API key is not configured

### DIFF
--- a/src/memory-ingest.ts
+++ b/src/memory-ingest.ts
@@ -2,6 +2,7 @@ import { generateContent, parseJsonResponse } from './gemini.js';
 import { cosineSimilarity, embedText } from './embeddings.js';
 import { getMemoriesWithEmbeddings, saveStructuredMemory, saveMemoryEmbedding } from './db.js';
 import { logger } from './logger.js';
+import { GOOGLE_API_KEY } from './config.js';
 
 // Callback for notifying when a high-importance memory is created.
 // Set by bot.ts to send a Telegram notification.
@@ -74,6 +75,7 @@ export async function ingestConversationTurn(
   assistantResponse: string,
   agentId = 'main',
 ): Promise<boolean> {
+  if (!GOOGLE_API_KEY) return false;
   // Hard filter: skip very short messages and commands
   if (userMessage.length <= 15 || userMessage.startsWith('/')) return false;
 


### PR DESCRIPTION
## Summary

- Adds a `GOOGLE_API_KEY` guard at the top of `ingestConversationTurn()` in `src/memory-ingest.ts`, so memory ingestion is silently skipped when Gemini is not configured
- This prevents an unhandled error that would occur when the function tried to call the Gemini API without a valid key
- A version of this fix was submitted previously but did not make it into recent builds, so this re-applies it cleanly against the current main branch

## Test plan

- [x] Start the bot without `GOOGLE_API_KEY` set in `.env` and confirm no crashes occur during conversation
- [x] Start the bot with `GOOGLE_API_KEY` set and confirm memory ingestion still works as expected
- [x] Verify `npm run build` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)