### PR TITLE
feat(agent): add Windows service management via PM2

### DIFF
--- a/src/agent-create.ts
+++ b/src/agent-create.ts
@@ -289,6 +289,8 @@ function generateServiceConfig(agentId: string): string | null {
     return generateLaunchdPlist(agentId);
   } else if (os.platform() === 'linux') {
     return generateSystemdUnit(agentId);
+  } else if (os.platform() === 'win32') {
+    return generatePm2Config(agentId);
   }
   return null;
 }
@@ -380,6 +382,33 @@ WantedBy=default.target
   return unitPath;
 }
 
+function generatePm2Config(agentId: string): string {
+  const configPath = path.join(PROJECT_ROOT, 'ecosystem.config.cjs');
+  const appName = `claudeclaw-${agentId}`;
+
+  const config = `module.exports = {
+  apps: [{
+    name: '${appName}',
+    script: 'dist/index.js',
+    args: '--agent ${agentId}',
+    cwd: __dirname,
+    env: {
+      NODE_ENV: 'production',
+    },
+    autorestart: true,
+    restart_delay: 5000,
+    error_file: 'store/${agentId}-error.log',
+    out_file: 'store/${agentId}-out.log',
+    merge_logs: true,
+    watch: false,
+  }],
+};
+`;
+
+  fs.writeFileSync(configPath, config, 'utf-8');
+  return configPath;
+}
+
 // ── Activate / Deactivate ────────────────────────────────────────────
 
 export interface ActivationResult {
@@ -394,6 +423,8 @@ export function activateAgent(agentId: string): ActivationResult {
       return activateLaunchd(agentId);
     } else if (os.platform() === 'linux') {
       return activateSystemd(agentId);
+    } else if (os.platform() === 'win32') {
+      return activatePm2(agentId);
     }
     return { ok: false, error: `Unsupported platform: ${os.platform()}` };
   } catch (err) {
@@ -464,6 +495,27 @@ function activateSystemd(agentId: string): ActivationResult {
   }
 }
 
+function activatePm2(agentId: string): ActivationResult {
+  const appName = `claudeclaw-${agentId}`;
+  const configPath = path.join(PROJECT_ROOT, 'ecosystem.config.cjs');
+
+  if (!fs.existsSync(configPath)) {
+    return { ok: false, error: `PM2 config not found: ${configPath}` };
+  }
+
+  try {
+    execSync(`pm2 start ecosystem.config.cjs --only ${appName}`, {
+      cwd: PROJECT_ROOT,
+      stdio: 'ignore',
+    });
+    execSync('pm2 save', { stdio: 'ignore' });
+    logger.info({ agentId }, 'Agent activated (pm2)');
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 export function deactivateAgent(agentId: string): { ok: boolean; error?: string } {
   try {
     if (os.platform() === 'darwin') {
@@ -482,6 +534,11 @@ export function deactivateAgent(agentId: string): { ok: boolean; error?: string 
       const unitPath = path.join(os.homedir(), '.config', 'systemd', 'user', `${serviceName}.service`);
       if (fs.existsSync(unitPath)) fs.unlinkSync(unitPath);
       try { execSync('systemctl --user daemon-reload', { stdio: 'ignore' }); } catch { /* ok */ }
+    } else if (os.platform() === 'win32') {
+      const appName = `claudeclaw-${agentId}`;
+      try { execSync(`pm2 stop ${appName}`, { stdio: 'ignore' }); } catch { /* ok */ }
+      try { execSync(`pm2 delete ${appName}`, { stdio: 'ignore' }); } catch { /* ok */ }
+      try { execSync('pm2 save', { stdio: 'ignore' }); } catch { /* ok */ }
     }
 
     // Kill the process if still running

--- a/src/agent-create.ts
+++ b/src/agent-create.ts
@@ -509,6 +509,14 @@ function activatePm2(agentId: string): ActivationResult {
       stdio: 'ignore',
     });
     execSync('pm2 save', { stdio: 'ignore' });
+
+    // Ensure PM2 resurrects processes after reboot (requires pm2-windows-startup)
+    try {
+      execSync('pm2-startup install', { stdio: 'ignore' });
+    } catch {
+      logger.warn({ agentId }, 'pm2-windows-startup not installed -- processes will not survive reboot. Run: npm install -g pm2-windows-startup');
+    }
+
     logger.info({ agentId }, 'Agent activated (pm2)');
     return { ok: true };
   } catch (err) {

--- a/src/security.ts
+++ b/src/security.ts
@@ -157,6 +157,10 @@ export function executeEmergencyKill(): void {
       try {
         execSync('systemctl --user stop "com.claudeclaw.*" 2>/dev/null', { stdio: 'ignore', timeout: 3000 });
       } catch { /* ok */ }
+    } else if (os.platform() === 'win32') {
+      try {
+        execSync('pm2 kill', { stdio: 'ignore', timeout: 3000 });
+      } catch { /* ok */ }
     }
   } catch { /* don't let anything prevent exit */ }
 


### PR DESCRIPTION
## Summary

- Adds Windows (win32) support to the agent service lifecycle using PM2 as the process manager, completing cross-platform coverage alongside macOS (launchd) and Linux (systemd)
- New functions in `agent-create.ts`: `generatePm2Config()` creates an `ecosystem.config.cjs`, `activatePm2()` starts the agent via PM2, and the deactivate path stops/deletes the PM2 process
- Adds a `win32` branch in `security.ts`'s emergency kill switch that runs `pm2 kill` to halt all ClaudeClaw services
- `activatePm2()` now calls `pm2-startup install` to register a Windows boot hook so processes survive reboots. Logs a warning if the package is not installed

## Prerequisites (Windows)

PM2 alone does not persist processes across reboots on Windows. Users need:

```
npm install -g pm2-windows-startup
```

The activation flow calls `pm2-startup install` automatically after `pm2 save`. If the package is missing, activation still succeeds but a warning is logged that reboot persistence is unavailable.

## Test plan

- [x] On Windows, run `npm run build` to verify TypeScript compiles without errors
- [x] Create a new agent and confirm `ecosystem.config.cjs` is generated in PROJECT_ROOT with correct app name, script path, args, and log file paths
- [x] Activate the agent and verify `pm2 list` shows the process running with the expected `claudeclaw-<agentId>` name
- [x] Deactivate the agent and confirm it is stopped and removed from `pm2 list`, and that `pm2 save` persists the change
- [x] Verify `pm2-startup install` is called during activation and registers the Windows boot hook
- [ ] Verify existing macOS (launchd) and Linux (systemd) paths are unaffected by the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)