### PR TITLE
fix(oauth-health): skip alert when credentials file absent (keychain auth)

### DIFF
--- a/src/oauth-health.ts
+++ b/src/oauth-health.ts
@@ -19,12 +19,25 @@ interface Credentials {
   };
 }
 
-function readCredentials(): Credentials | null {
+type ReadResult =
+  | { kind: 'ok'; creds: Credentials }
+  | { kind: 'missing' }
+  | { kind: 'invalid' };
+
+function readCredentials(): ReadResult {
+  let raw: string;
   try {
-    const raw = fs.readFileSync(CREDENTIALS_PATH, 'utf-8');
-    return JSON.parse(raw) as Credentials;
+    raw = fs.readFileSync(CREDENTIALS_PATH, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { kind: 'missing' };
+    }
+    return { kind: 'invalid' };
+  }
+  try {
+    return { kind: 'ok', creds: JSON.parse(raw) as Credentials };
   } catch {
-    return null;
+    return { kind: 'invalid' };
   }
 }
 
@@ -49,22 +62,29 @@ async function checkOAuthHealth(sender: Sender): Promise<void> {
     return;
   }
 
-  const creds = readCredentials();
+  const result = readCredentials();
 
-  if (!creds?.claudeAiOauth?.expiresAt) {
+  // Missing file = keychain-based auth on modern macOS. Subprocess still finds
+  // credentials via the Claude CLI's own lookup chain. Log and skip — don't spam.
+  if (result.kind === 'missing') {
+    logger.debug({ path: CREDENTIALS_PATH }, 'OAuth credentials file absent (likely keychain auth) — skipping check');
+    lastAlertLevel = 'none';
+    return;
+  }
+
+  if (result.kind === 'invalid' || !result.creds?.claudeAiOauth?.expiresAt) {
     if (lastAlertLevel !== 'expired') {
       lastAlertLevel = 'expired';
       await sender(
         '<b>OAuth Health Check</b>\n\n' +
-        'Cannot read OAuth token.\n' +
-        'File missing or invalid structure.\n\n' +
+        'OAuth credentials file exists but is unreadable or malformed.\n\n' +
         'Run: <code>claude auth login</code>',
       );
     }
     return;
   }
 
-  const expiresAt = creds.claudeAiOauth.expiresAt;
+  const expiresAt = result.creds.claudeAiOauth.expiresAt;
   const now = Date.now();
   const remainingMs = expiresAt - now;
   const remainingHours = Math.floor(remainingMs / (60 * 60 * 1000));


### PR DESCRIPTION
## Summary

On modern macOS, the Claude CLI stores OAuth credentials in Keychain instead of `~/.claude/.credentials.json`. The current OAuth health check treats a missing credentials file the same as a malformed one and repeatedly alerts the user via Telegram, even though the spawned Claude subprocess authenticates successfully via the CLI's own Keychain lookup.

## Change

Distinguish three read outcomes in `src/oauth-health.ts`:

- **File missing (ENOENT)** → log debug and skip. Keychain auth is the valid modern default, not a broken state.
- **File exists but unreadable or invalid JSON** → alert (unchanged behavior).
- **File parsed but missing `expiresAt`** → alert (unchanged behavior).

Expiry and expiring-soon alerts behave identically to before.

## Motivation

I set up ClaudeClaw on a Mac where `claude` auth lives in Keychain (no `~/.claude/.credentials.json` ever existed on disk). The bot otherwise worked perfectly — spawned Claude subprocesses authenticated and responded — but the health check fired every 30 minutes with "Cannot read OAuth token. File missing or invalid structure." False positives that drowned out the signal when a real expiry alert eventually matters.

## Test plan

- [x] Verified on macOS 14 with no credentials file on disk: bot starts cleanly, no spurious alert, agent responses succeed.
- [x] `npm run build` passes.
- [ ] Test case for malformed-file path (file exists, bad JSON) — alert still fires.
- [ ] Test case for expired token — alert still fires.

No changes to the public API of `initOAuthHealthCheck`, `OAUTH_CHECK_MINUTES`, or `OAUTH_ALERT_HOURS`.

Happy to adjust the log message or wording if you have preferences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
