### PR TITLE
fix(sdk): strip nested-session env vars before SDK query

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -175,6 +175,18 @@ export async function runAgent(
   const secrets = readEnvFile(['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY']);
 
   const sdkEnv: Record<string, string | undefined> = { ...process.env };
+  // Strip nested-session markers inherited from a parent Claude Code process
+  // (e.g. when ClaudeClaw is launched from within an interactive Claude Code
+  // session or a PM2 daemon that was started from one). The vendored CLI
+  // aborts with "cannot be launched inside another Claude Code session" if
+  // these are present. See claude-agent-sdk cli.js nested-session check.
+  delete sdkEnv.CLAUDECODE;
+  delete sdkEnv.CLAUDE_CODE_ENTRYPOINT;
+  delete sdkEnv.CLAUDE_CODE_EXECPATH;
+  delete sdkEnv.CLAUDE_AGENT_SDK_VERSION;
+  delete sdkEnv.CLAUDE_CODE_SDK_HAS_OAUTH_REFRESH;
+  delete sdkEnv.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST;
+  delete sdkEnv.CLAUDE_INTERNAL_FC_OVERRIDES;
   if (secrets.CLAUDE_CODE_OAUTH_TOKEN) {
     sdkEnv.CLAUDE_CODE_OAUTH_TOKEN = secrets.CLAUDE_CODE_OAUTH_TOKEN;
   }


### PR DESCRIPTION
## Problem

When ClaudeClaw is launched from inside an active Claude Code session (e.g. spawned by PM2 from a shell where Claude Code was running, or invoked as a child of another CC session), the vendored CLI aborts with:

> Claude Code cannot be launched inside another Claude Code session.

This is because `@anthropic-ai/claude-agent-sdk`'s `query()` inherits `process.env`, which includes markers that the CLI reads to detect nested sessions:
- `CLAUDECODE`
- `CLAUDE_CODE_ENTRYPOINT`
- `CLAUDE_CODE_EXECPATH`
- `CLAUDE_AGENT_SDK_VERSION`
- `CLAUDE_CODE_SDK_HAS_OAUTH_REFRESH`
- `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST`
- `CLAUDE_INTERNAL_FC_OVERRIDES`

Since ClaudeClaw is itself an orchestrator that spawns the SDK CLI, those markers are stale — they describe the parent shell, not the ClaudeClaw runtime.

## Fix

Build a sanitized `sdkEnv` by filtering those keys out of `process.env` before passing to `query()`. Small, surgical change; no behavior change for normal (non-nested) launches.

## Test plan

- [x] Bot launched under PM2 spawned from an active CC session — previously failed, now runs cleanly
- [x] Normal desktop launch (no parent CC) still works
- [x] Telegram bot responds to messages, SDK streams tokens, no regressions observed over ~1 hour of use

## Context

Found while deploying ClaudeClaw v1.1.0 as a Telegram bot (\`@timecm_BOT\`) on a Windows workstation where Claude Code was the parent shell. Root cause confirmed by inspecting the vendored \`node_modules/@anthropic-ai/claude-code/cli.js\` nested-session check.